### PR TITLE
fix: compat with commonjs module output

### DIFF
--- a/typescript/src/core.ts
+++ b/typescript/src/core.ts
@@ -180,7 +180,7 @@ export default function (opts: Options = {}): TransformerFactory<SourceFile> {
             if (!startsWithLowerCase(name.text)) {
                 const temp = createTempVariable()
                 // uniq = name
-                const assignment = factory.createAssignment(temp, factory.createIdentifier(name.text))
+                const assignment = factory.createAssignment(temp, name)
                 // $reg$(uniq, "name")
                 return [factory.createExpressionStatement(assignment), createComponentRegisterCall(temp, name.text)]
             }
@@ -230,11 +230,7 @@ export default function (opts: Options = {}): TransformerFactory<SourceFile> {
             }
         }
         function createTempVariable() {
-            return factory.createTempVariable(
-                context.hoistVariableDeclaration,
-                // @ts-ignore the second parameter "reservedInNestedScopes?: boolean" has a private signature
-                true
-            )
+            return factory.createTempVariable(context.hoistVariableDeclaration, true)
         }
         /**
          * ! This function does not consider variable shadowing !


### PR DESCRIPTION
reuse the original identifier in the assignment.
this way, when typescript transpiles:
`export const Comp = ...`
to
`exports.Comp = ...`

it will also change the temp variable from `_b = Comp` to `_b = exports.Comp`

Tiny fix, but without it evaluation fails with `ReferenceError: Comp is not defined`.

Also removed a no-longer-needed @ts-ignore.